### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Run Tests
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ '*' ]


### PR DESCRIPTION
Potential fix for [https://github.com/vigiloauth/vigilo/security/code-scanning/1](https://github.com/vigiloauth/vigilo/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the operations performed in this workflow. This ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
