### PR TITLE
Added password policy Admin endpoint w/ tests

### DIFF
--- a/docs/user_guide/identity/endpoints/admin_handler/get_password_policy.md
+++ b/docs/user_guide/identity/endpoints/admin_handler/get_password_policy.md
@@ -1,0 +1,91 @@
+# Get Password Policy
+
+## Endpoint
+```http
+GET /internal/identity/admins/password-policy
+```
+
+---
+
+**Description:**
+This endpoint retrieves the current password policy configuration for the server. The password policy defines the complexity requirements for user passwords, including requirements for uppercase letters, numbers, symbols, and minimum length.
+
+>**Note:** To access this endpoint, users must have the `ADMIN` role associated to them.
+
+---
+
+## Headers
+| Key             | Value                         | Description                              |
+| :-------------- | :---------------------------- | :----------------------------------------|
+| Content-Type    | application/json              | Indicates that the response body is JSON.|
+| Date            | Tue, 03 Dec 2024 19:38:16 GMT | The date and time the request was made.  |
+| Authorization   | Bearer <token>                | The bearer token for authentication.     |
+
+---
+
+## Example Request
+```http
+GET /internal/identity/admins/password-policy HTTP/1.1
+Accept: application/json
+Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+---
+
+## Responses
+
+### Success Response
+#### HTTP Status Code: `200 OK`
+#### Response Body:
+```json
+{
+  "require_upper": true,
+  "require_number": true,
+  "require_symbol": false,
+  "min_length": 8
+}
+```
+
+#### Response Fields:
+| Field            | Type    | Description                                           |
+|:-----------------|:--------|:------------------------------------------------------|
+| `require_upper`  | `bool`  | Whether uppercase letters are required in passwords.  |
+| `require_number` | `bool`  | Whether numbers are required in passwords.            |
+| `require_symbol` | `bool`  | Whether symbols are required in passwords.            |
+| `min_length`     | `int`   | Minimum required password length.                     |
+
+---
+
+## Error Responses
+
+### 1. Insufficient Role
+#### HTTP Status Code: `403 Forbidden`
+#### Response Body:
+```json
+{
+  "error": "insufficient_role",
+  "error_description": "the request requires higher privileges than provided by the access token"
+}
+```
+
+### 2. Unauthorized
+#### HTTP Status Code: `401 Unauthorized`
+#### Response Body:
+```json
+{
+  "error": "invalid_token",
+  "error_description": "the access token is invalid or has expired"
+}
+```
+
+---
+
+## Notes
+- This endpoint returns the currently active password policy configuration.
+- The password policy settings can be configured via environment variables or the configuration file.
+- These settings apply to all password-related operations (registration, password reset, etc.).
+- Default values if not configured:
+  - `require_upper`: `false`
+  - `require_number`: `false`
+  - `require_symbol`: `false`
+  - `min_length`: `5`

--- a/idp/config/password_config.go
+++ b/idp/config/password_config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+
+	domain "github.com/vigiloauth/vigilo/v2/internal/domain/passwords"
 )
 
 const defaultRequiredPasswordLength int = 5
@@ -157,5 +159,14 @@ func (cfg *PasswordConfig) loadOptions(opts ...PasswordConfigOptions) {
 		}
 	} else {
 		cfg.logger.Info(cfg.module, "", "Using default password config")
+	}
+}
+
+func (cfg *PasswordConfig) GetPasswordPolicy() domain.PasswordPolicyResponse {
+	return domain.PasswordPolicyResponse{
+		RequireUpper:  cfg.RequireUppercase(),
+		RequireNumber: cfg.RequireNumber(),
+		RequireSymbol: cfg.RequireSymbol(),
+		MinLength:     cfg.MinLength(),
 	}
 }

--- a/internal/domain/passwords/model.go
+++ b/internal/domain/passwords/model.go
@@ -1,0 +1,8 @@
+package passwords
+
+type PasswordPolicyResponse struct {
+	RequireUpper  bool `json:"require_upper"`
+	RequireNumber bool `json:"require_number"`
+	RequireSymbol bool `json:"require_symbol"`
+	MinLength     int  `json:"min_length"`
+}

--- a/internal/handlers/admin_handler.go
+++ b/internal/handlers/admin_handler.go
@@ -18,6 +18,13 @@ type AdminHandler struct {
 	module      string
 }
 
+type PasswordPolicyResponse struct {
+	RequireUpper  bool `json:"require_upper"`
+	RequireNumber bool `json:"require_number"`
+	RequireSymbol bool `json:"require_symbol"`
+	MinLength     int  `json:"min_length"`
+}
+
 func NewAdminHandler(auditLogger domain.AuditLogger) *AdminHandler {
 	return &AdminHandler{
 		auditLogger: auditLogger,
@@ -54,6 +61,22 @@ func (h *AdminHandler) GetAuditEvents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	web.WriteJSON(w, http.StatusOK, events)
+}
+
+func (h *AdminHandler) GetPasswordPolicy(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	requestID := utils.GetRequestID(ctx)
+	h.logger.Info(h.module, requestID, "[GetPasswordPolicy]: Processing request")
+
+	cfg := config.GetServerConfig().PasswordConfig()
+	resp := PasswordPolicyResponse{
+		RequireUpper:  cfg.RequireUppercase(),
+		RequireNumber: cfg.RequireNumber(),
+		RequireSymbol: cfg.RequireSymbol(),
+		MinLength:     cfg.MinLength(),
+	}
+
+	web.WriteJSON(w, http.StatusOK, resp)
 }
 
 func (h *AdminHandler) buildFilters(w http.ResponseWriter, query url.Values) map[string]any {

--- a/internal/handlers/admin_handler.go
+++ b/internal/handlers/admin_handler.go
@@ -18,13 +18,6 @@ type AdminHandler struct {
 	module      string
 }
 
-type PasswordPolicyResponse struct {
-	RequireUpper  bool `json:"require_upper"`
-	RequireNumber bool `json:"require_number"`
-	RequireSymbol bool `json:"require_symbol"`
-	MinLength     int  `json:"min_length"`
-}
-
 func NewAdminHandler(auditLogger domain.AuditLogger) *AdminHandler {
 	return &AdminHandler{
 		auditLogger: auditLogger,
@@ -69,12 +62,7 @@ func (h *AdminHandler) GetPasswordPolicy(w http.ResponseWriter, r *http.Request)
 	h.logger.Info(h.module, requestID, "[GetPasswordPolicy]: Processing request")
 
 	cfg := config.GetServerConfig().PasswordConfig()
-	resp := PasswordPolicyResponse{
-		RequireUpper:  cfg.RequireUppercase(),
-		RequireNumber: cfg.RequireNumber(),
-		RequireSymbol: cfg.RequireSymbol(),
-		MinLength:     cfg.MinLength(),
-	}
+	resp := cfg.GetPasswordPolicy()
 
 	web.WriteJSON(w, http.StatusOK, resp)
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -24,6 +24,13 @@ func (rc *RouterConfig) getAdminRoutes() RouteGroup {
 				SetHandler(handler.GetAuditEvents).
 				SetDescription("Get audit events").
 				Build(),
+
+			NewRoute().
+				SetMethods(http.MethodGet).
+				SetPattern(web.AdminEndpoints.GetPasswordPolicy).
+				SetHandler(handler.GetPasswordPolicy).
+				SetDescription("Get password policy").
+				Build(),
 		},
 	}
 }

--- a/internal/web/endpoints.go
+++ b/internal/web/endpoints.go
@@ -7,6 +7,7 @@ const (
 	defaultTokenEndpoint  string = "/tokens"
 	defaultAdminEndpoint  string = "/admins"
 	wellKnown             string = "/.well-known"
+	internalEndpoint      string = "/internal"
 )
 
 var UserEndpoints = struct {
@@ -54,11 +55,11 @@ var OAuthEndpoints = struct {
 }
 
 var AdminEndpoints = struct {
-	GetAuditEvents string
+	GetAuditEvents    string
 	GetPasswordPolicy string
 }{
-	GetAuditEvents: defaultAdminEndpoint + "/audit-events",
-	GetPasswordPolicy: defaultAdminEndpoint + "/password-policy",
+	GetAuditEvents:    defaultAdminEndpoint + "/audit-events",
+	GetPasswordPolicy: internalEndpoint + defaultAdminEndpoint + "/password-policy",
 }
 
 var OIDCEndpoints = struct {

--- a/internal/web/endpoints.go
+++ b/internal/web/endpoints.go
@@ -55,8 +55,10 @@ var OAuthEndpoints = struct {
 
 var AdminEndpoints = struct {
 	GetAuditEvents string
+	GetPasswordPolicy string
 }{
 	GetAuditEvents: defaultAdminEndpoint + "/audit-events",
+	GetPasswordPolicy: defaultAdminEndpoint + "/password-policy",
 }
 
 var OIDCEndpoints = struct {

--- a/tests/integration/admin_handler_integration_test.go
+++ b/tests/integration/admin_handler_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/vigiloauth/vigilo/v2/idp/config"
 	"github.com/vigiloauth/vigilo/v2/internal/constants"
 	"github.com/vigiloauth/vigilo/v2/internal/web"
 )
@@ -64,6 +65,83 @@ func TestAdminHandler_GetAuditEvents(t *testing.T) {
 
 		rr := testContext.SendHTTPRequest(http.MethodGet, endpoint, nil, headers)
 
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+	})
+}
+
+func TestAdminHandler_GetPasswordPolicy(t *testing.T) {
+	t.Run("Success with all requirements", func(t *testing.T) {
+		testContext := NewVigiloTestContext(t)
+		defer testContext.TearDown()
+
+		testContext.WithAdminToken(testUserID, time.Duration(2*time.Hour))
+		headers := map[string]string{"Authorization": constants.BearerAuthHeader + testContext.JWTToken}
+		endpoint := web.AdminEndpoints.GetPasswordPolicy
+
+		// set policy to known values using public configuration API
+		testContext.WithCustomConfig(
+			config.WithPasswordConfig(
+				config.NewPasswordConfig(
+					config.WithUppercase(),
+					config.WithNumber(),
+					config.WithMinLength(12),
+				),
+			),
+		)
+
+		rr := testContext.SendHTTPRequest(http.MethodGet, endpoint, nil, headers)
+
+		// Assert policy is returned
+		assert.Contains(t, rr.Body.String(), `"require_upper":true`)
+		assert.Contains(t, rr.Body.String(), `"require_number":true`)
+		assert.Contains(t, rr.Body.String(), `"require_symbol":false`)
+		assert.Contains(t, rr.Body.String(), `"min_length":12`)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("Success with some requirements", func(t *testing.T) {
+		testContext := NewVigiloTestContext(t)
+		defer testContext.TearDown()
+
+		testContext.WithAdminToken(testUserID, time.Duration(2*time.Hour))
+		headers := map[string]string{"Authorization": constants.BearerAuthHeader + testContext.JWTToken}
+		endpoint := web.AdminEndpoints.GetPasswordPolicy
+
+		// set policy to known values using public configuration API
+		testContext.WithCustomConfig(
+			config.WithPasswordConfig(
+				config.NewPasswordConfig(
+					config.WithUppercase(),
+					config.WithSymbol(),
+					config.WithMinLength(8),
+				),
+			),
+		)
+
+		rr := testContext.SendHTTPRequest(http.MethodGet, endpoint, nil, headers)
+
+		// Assert policy is returned
+		assert.Contains(t, rr.Body.String(), `"require_upper":true`)
+		assert.Contains(t, rr.Body.String(), `"require_number":false`)
+		assert.Contains(t, rr.Body.String(), `"require_symbol":true`)
+		assert.Contains(t, rr.Body.String(), `"min_length":8`)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("Error is returned when user does not have the required roles", func(t *testing.T) {
+		testContext := NewVigiloTestContext(t)
+		defer testContext.TearDown()
+
+		testContext.WithUser([]string{constants.UserRole})
+		testContext.WithJWTToken(testUserID, time.Duration(2*time.Hour))
+
+		headers := map[string]string{"Authorization": constants.BearerAuthHeader + testContext.JWTToken}
+		endpoint := web.AdminEndpoints.GetPasswordPolicy
+
+		rr := testContext.SendHTTPRequest(http.MethodGet, endpoint, nil, headers)
+		
 		assert.Equal(t, http.StatusForbidden, rr.Code)
 	})
 }


### PR DESCRIPTION
Admin can now call an endpoint called "/password-policy" which will return the current configured password policy in a struct. The struct contains bools for whether the current policy require uppercase letters, numbers, and/or symbols in the password. It also includes the minimum length of the password policy in int form. Closes #369